### PR TITLE
Add errors

### DIFF
--- a/src/server/animals/controllers/start.js
+++ b/src/server/animals/controllers/start.js
@@ -1,12 +1,22 @@
 import { sessionNames } from '~/src/server/common/constants/session-names'
 import { saveToAnimal } from '~/src/server/animals/helpers/form/save-to-animal'
+import { initUpload } from '~/src/server/common/helpers/upload/init-upload'
 
 const startController = {
   handler: async (request, h) => {
     request.yar.clear(sessionNames.animals)
     request.yar.clear(sessionNames.validationFailure)
 
-    await saveToAnimal(request, h, {})
+    const secureUpload = await initUpload({
+      successRedirect: 'http://localhost:3000/animals/add/your-details',
+      failureRedirect: 'http://localhost:3000/animals/add/upload-picture',
+      scanResultCallback: 'http://localhost:3000',
+      destinationBucket: 'my-bucket',
+      acceptedMimeTypes: ['.pdf', '.csv', '.png', 'image/jpeg'],
+      maxFileSize: 100
+    })
+
+    await saveToAnimal(request, h, { secureUpload })
 
     return h.redirect('/animals/add/details')
   }

--- a/src/server/animals/controllers/upload-form.js
+++ b/src/server/animals/controllers/upload-form.js
@@ -1,22 +1,17 @@
-import { initUpload } from '~/src/server/common/helpers/upload/init-upload'
-import { saveToAnimal } from '~/src/server/animals/helpers/form/save-to-animal'
+import { provideAnimalSession } from '~/src/server/animals/helpers/pre/provide-animal-session'
 
 const uploadFormController = {
+  options: {
+    pre: [provideAnimalSession]
+  },
   handler: async (request, h) => {
-    const secureUpload = await initUpload({
-      successRedirect: 'http://localhost:3000/animals/add/your-details',
-      failureRedirect: 'http://localhost:3000/animals/add/upload-picture',
-      scanResultCallback: 'http://localhost:3000',
-      destinationBucket: 'my-bucket',
-      acceptedMimeTypes: ['.pdf', '.csv', '.png', 'image/jpeg'],
-      maxFileSize: 100
-    })
-
-    await saveToAnimal(request, h, { uploadId: secureUpload.id })
+    const animalSession = request.pre.animalSession
+    const uploadError = animalSession?.uploadStatus?.error
 
     return h.view('animals/views/upload-form', {
       pageTitle: 'Add animal',
-      action: secureUpload.url,
+      uploadError,
+      action: animalSession.secureUpload.url,
       heading: 'Seen an Animal?',
       breadcrumbs: [
         {

--- a/src/server/animals/views/details-form.njk
+++ b/src/server/animals/views/details-form.njk
@@ -24,6 +24,9 @@
               hint: {
                 text: "What is the animals name?"
               },
+              attributes: {
+                "data-1p-ignore": ""
+              },
               errorMessage: {
                 text: formErrors.name.message
               } if formErrors.name.message

--- a/src/server/animals/views/upload-form.njk
+++ b/src/server/animals/views/upload-form.njk
@@ -23,7 +23,10 @@
               },
               hint: {
                 text: "Filetypes of .jpeg with a max size of 100kb"
-              }
+              },
+              errorMessage: {
+                text: uploadError
+              } if uploadError
             }) }}
 
           {% endcall %}

--- a/src/server/common/helpers/upload/save-upload-status.js
+++ b/src/server/common/helpers/upload/save-upload-status.js
@@ -2,11 +2,16 @@ import { sessionNames } from '~/src/server/common/constants/session-names'
 import { fetchStatus } from '~/src/server/common/helpers/upload/fetch-status'
 import { saveToAnimal } from '~/src/server/animals/helpers/form/save-to-animal'
 
+// TODO needs a better name
 async function saveUploadStatus(request, h) {
   const animalsSession = request.yar.get(sessionNames.animals)
-  const uploadStatus = await fetchStatus(animalsSession.uploadId)
+  const uploadId = animalsSession?.secureUpload?.id
 
-  await saveToAnimal(request, h, { uploadStatus })
+  if (uploadId) {
+    const uploadStatus = await fetchStatus(uploadId)
+
+    await saveToAnimal(request, h, { uploadStatus })
+  }
 }
 
 export { saveUploadStatus }


### PR DESCRIPTION
Add errors from the `cdp-uploader`

![with-errors](https://github.com/DEFRA/cdp-example-node-frontend/assets/2305016/46c853d8-5703-47d0-aa03-55f5c3ceb86f)


## Associated PR

https://github.com/DEFRA/cdp-uploader/pull/11

> Adds `"error": "Choose a file",` to the UI session 

```
const uiSession = {
  animalsSessionObj: {
    secureUpload: {
      url: 'http://localhost:7337/upload/6fe458df-637d-40b9-af65-bbdbe6d58799',
      id: '6fe458df-637d-40b9-af65-bbdbe6d58799'
    },
    name: 'Hector',
    kind: 'yak',
    uploadStatus: {
      successRedirect: 'http://localhost:3000/animals/add/your-details',
      failureRedirect: 'http://localhost:3000/animals/add/upload-picture',
      scanResultCallback: 'http://localhost:3000',
      destinationBucket: 'my-bucket',
      acceptedMimeTypes: ['.pdf', '.csv', '.png', 'image/jpeg'],
      maxFileSize: 100,
      destinationPath: '',
      initiated: '2024-03-25T18:55:05.344Z',
      error: 'Choose a file',
      fields: {
        file: {
          fileName: 'unicorn.jpg',
          contentType: 'image/jpeg'
        }
      },
      quarantined: '2024-03-25T18:55:24.212Z'
    },
    phoneNumber: '445454'
  }
}
```