### PR TITLE
Replaces presigned with just proxying the file.

### DIFF
--- a/src/server/animals/helpers/pre/provide-animal.js
+++ b/src/server/animals/helpers/pre/provide-animal.js
@@ -1,6 +1,4 @@
-import { config } from '~/src/config'
 import { getAnimal } from '~/src/server/animals/helpers/fetch/get-animal'
-import { buildS3PresignedUrl } from '~/src/server/common/helpers/aws/build-s3-presigned-url'
 
 const provideAnimal = {
   method: async (request, h) => {
@@ -9,18 +7,13 @@ const provideAnimal = {
     if (animal) {
       // TODO a little awkward/brittle - can the info from the uploader be more fine grained and list bucket and key?
       const filePathParts = animal.fileUrl.split('/')
-      const bucket = filePathParts.at(0)
       const key = filePathParts.slice(1).join('/')
 
-      const presignedFileUrl = await buildS3PresignedUrl({
-        bucket,
-        key,
-        region: config.get('awsRegion')
-      })
+      const fileUrl = '/file/' + key
 
       return {
         ...animal,
-        presignedFileUrl
+        fileUrl
       }
     }
 

--- a/src/server/animals/views/animal.njk
+++ b/src/server/animals/views/animal.njk
@@ -16,7 +16,7 @@
         <p><strong class="govuk-!-margin-right-1">Phone number:</strong>{{ animal.phoneNumber }}</p>
 
         <img class="app-img"
-             src="{{ animal.presignedFileUrl }}"
+             src="{{ animal.fileUrl }}"
              alt="{{ animal.name }} picture">
       </div>
     </div>

--- a/src/server/common/helpers/s3-client.js
+++ b/src/server/common/helpers/s3-client.js
@@ -1,0 +1,13 @@
+import { S3Client } from '@aws-sdk/client-s3'
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
+import { config } from '~/src/config'
+
+const s3Client = new S3Client({
+  credentials: fromNodeProviderChain(),
+  ...(config.get('isDevelopment') && {
+    endpoint: config.get('localstackEndpoint'),
+    forcePathStyle: true
+  })
+})
+
+export { s3Client }

--- a/src/server/files/file-controller.js
+++ b/src/server/files/file-controller.js
@@ -1,0 +1,32 @@
+import { s3Client } from '~/src/server/common/helpers/s3-client'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import { config } from '~/src/config'
+
+/**
+ * Provides access to files in the s3 bucket.
+ * In a production system you may want to check the requester has permissions to access the file
+ * since this example provides access to any file in the bucket if the requester knows the key.
+ */
+const fileController = {
+  handler: async (request, h) => {
+    const fileId = request.params.id
+
+    const command = new GetObjectCommand({
+      Bucket: config.get('uploadBucketName'),
+      Key: fileId
+    })
+
+    try {
+      const response = await s3Client.send(command)
+      return h
+        .response(response.Body)
+        .header('Content-Type', response.ContentType)
+        .code(200)
+    } catch (err) {
+      request.logger.error(err)
+      return h.response('File Not Found').code(404)
+    }
+  }
+}
+
+export { fileController }

--- a/src/server/files/index.js
+++ b/src/server/files/index.js
@@ -1,0 +1,16 @@
+import { fileController } from '~/src/server/files/file-controller'
+
+const files = {
+  plugin: {
+    name: 'files',
+    register: async (server) => {
+      server.route({
+        method: 'GET',
+        path: '/file/{id}',
+        ...fileController
+      })
+    }
+  }
+}
+
+export { files }

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -5,6 +5,7 @@ import { home } from '~/src/server/home'
 import { creatures } from '~/src/server/creatures'
 import { animals } from '~/src/server/animals'
 import { serveStaticFiles } from '~/src/server/common/helpers/serve-static-files'
+import { files } from '~/src/server/files'
 
 const router = {
   plugin: {
@@ -16,6 +17,7 @@ const router = {
         home,
         animals,
         creatures,
+        files,
         serveStaticFiles
       ])
     }


### PR DESCRIPTION
Presigned urls are a bit niche and we dont typically have permissions. Just pulling the file from s3 and doing stuff with it feels like a more generic usage.