### PR TITLE
Add more error validation

### DIFF
--- a/src/server/animals/controllers/status-poller.js
+++ b/src/server/animals/controllers/status-poller.js
@@ -29,7 +29,7 @@ const statusPollerController = {
 
     // Mime type mismatch
     if (!hasCorrectMimeType) {
-      setError(`Files of ${acceptedMimeTypes.join(', ')} only`)
+      setError(`Files of ${acceptedMimeTypes.join(', ')}`)
 
       return h.redirect('/animals/add/upload-picture')
     }

--- a/src/server/animals/controllers/status-poller.js
+++ b/src/server/animals/controllers/status-poller.js
@@ -1,40 +1,55 @@
-import { sessionNames } from '~/src/server/common/constants/session-names'
 import { saveToAnimal } from '~/src/server/animals/helpers/form/save-to-animal'
 import { provideStatus } from '~/src/server/common/helpers/pre/provide-status'
+import { populateErrorFlashMessage } from '~/src/server/common/helpers/form/populate-error-flash-message'
 
 const statusPollerController = {
   options: {
     pre: [provideStatus]
   },
   handler: async (request, h) => {
+    const setError = populateErrorFlashMessage(request)
     const status = request.pre.status
+    const fileUpload = status.files.at(0)
+    const acceptedMimeTypes = status.acceptedMimeTypes
     const hasUploadedFile = status?.files.length > 0
+    const hasBeenVirusChecked = status?.uploadStatus === 'ready'
+    const hasPassedVirusCheck = status?.numberOfInfectedFiles === 0
+    const fileUploadSizeMb = fileUpload?.contentLength / 1024
+    const fileSizeLimitExceeded = fileUploadSizeMb > status?.maxFileSize
+    const hasCorrectMimeType = acceptedMimeTypes.includes(
+      fileUpload?.contentType
+    )
 
-    // No file uploaded - Return to upload form with errors
+    // No file uploaded
     if (!hasUploadedFile) {
-      request.yar.flash(sessionNames.validationFailure, {
-        formErrors: { file: { message: 'Choose a file' } }
-      })
+      setError('Choose a file')
 
       return h.redirect('/animals/add/upload-picture')
     }
 
-    const hasBeenVirusChecked = status?.uploadStatus === 'ready'
-    const hasPassedVirusCheck = status?.numberOfInfectedFiles === 0
+    // Mime type mismatch
+    if (!hasCorrectMimeType) {
+      setError(`Files of ${acceptedMimeTypes.join(', ')} only`)
 
-    // Virus check failed - Return to upload form with errors
+      return h.redirect('/animals/add/upload-picture')
+    }
+
+    // Filesize limit exceeded
+    if (fileSizeLimitExceeded) {
+      setError(`Max file size of ${status?.maxFileSize}`)
+
+      return h.redirect('/animals/add/upload-picture')
+    }
+
+    // Virus check failed
     if (hasBeenVirusChecked && !hasPassedVirusCheck) {
-      request.yar.flash(sessionNames.validationFailure, {
-        formErrors: { file: { message: 'Virus check failed' } }
-      })
+      setError('Virus check failed')
 
       return h.redirect('/animals/add/upload-picture')
     }
 
     // File has successfully passed virus check and is ready to be used/stored in session/db
     if (hasBeenVirusChecked && hasPassedVirusCheck) {
-      const fileUpload = status.files.at(0)
-
       await saveToAnimal(request, h, {
         file: {
           filename: fileUpload.filename,

--- a/src/server/animals/controllers/status-poller.js
+++ b/src/server/animals/controllers/status-poller.js
@@ -29,7 +29,11 @@ const statusPollerController = {
 
     // Mime type mismatch
     if (!hasCorrectMimeType) {
-      setError(`Files of ${acceptedMimeTypes.join(', ')}`)
+      setError(
+        `${acceptedMimeTypes
+          .map((mimeType) => '.' + mimeType.split('/')[1])
+          .join(', ')} files only`
+      )
 
       return h.redirect('/animals/add/upload-picture')
     }

--- a/src/server/animals/controllers/upload-form.js
+++ b/src/server/animals/controllers/upload-form.js
@@ -12,7 +12,7 @@ const uploadFormController = {
     const secureUpload = await initUpload({
       successRedirect: redirectUrl,
       failureRedirect: redirectUrl,
-      acceptedMimeTypes: ['.pdf', '.csv', '.png', 'image/jpeg'],
+      acceptedMimeTypes: ['image/png', 'image/jpeg'],
       maxFileSize: 100,
       destinationBucket,
       destinationPath: '/animals'

--- a/src/server/animals/views/upload-form.njk
+++ b/src/server/animals/views/upload-form.njk
@@ -24,9 +24,6 @@
               hint: {
                 text: "Filetypes of .jpeg with a max size of 100kb"
               },
-              attributes: {
-                multiple: "multiple"
-              },
               errorMessage: {
                 text: formErrors.file.message
               } if formErrors.file.message

--- a/src/server/animals/views/upload-form.njk
+++ b/src/server/animals/views/upload-form.njk
@@ -22,7 +22,7 @@
                 classes: "govuk-label--m"
               },
               hint: {
-                text: "Filetypes of .jpeg with a max size of 100kb"
+                text: "File types of .png or .jpeg with a max size of 100 MB"
               },
               errorMessage: {
                 text: formErrors.file.message

--- a/src/server/common/helpers/form/populate-error-flash-message.js
+++ b/src/server/common/helpers/form/populate-error-flash-message.js
@@ -1,0 +1,8 @@
+import { sessionNames } from '~/src/server/common/constants/session-names'
+
+const populateErrorFlashMessage = (request) => (message) =>
+  request.yar.flash(sessionNames.validationFailure, {
+    formErrors: { file: { message } }
+  })
+
+export { populateErrorFlashMessage }

--- a/src/server/home/index.njk
+++ b/src/server/home/index.njk
@@ -7,7 +7,7 @@
   }) }}
   <main class="govuk-body">
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-three-quarters">
         <p>
           Welcome 👋🏻 to the Example Node Frontend. A playground to show case examples of how to do things in a CDP
           Node.js
@@ -16,8 +16,8 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row govuk-!-margin-bottom-4">
-      <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-m">Multistep form with single file upload</h2>
         <p>
           The <a href="/animals" class="govuk-link govuk-link--no-visited-state">Animals</a> multistep form is an
@@ -26,9 +26,10 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>A multistep form flow</li>
           <li>With Redis session</li>
-          <li>Virus scanning of files via the <a href="https://github.com/DEFRA/cdp-uploader"
-                                                 rel="noreferrer noopener" target="_blank"
-                                                 class="govuk-link  govuk-link--no-visited-state">
+          <li>Virus scanning and uploading of files to your bucket via the <a
+              href="https://github.com/DEFRA/cdp-uploader"
+              rel="noreferrer noopener" target="_blank"
+              class="govuk-link  govuk-link--no-visited-state">
               cdp-uploader</a> service
           </li>
           <li>Form validation</li>
@@ -41,8 +42,8 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row govuk-!-margin-bottom-4">
-      <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-m">Single page form with multi-file upload</h2>
         <p>
           The <a href="/creatures" class="govuk-link govuk-link--no-visited-state">Creatures</a> form is an example of:
@@ -50,9 +51,10 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>A single page form</li>
           <li>Multi-file input</li>
-          <li>Virus scanning of files via the <a href="https://github.com/DEFRA/cdp-uploader"
-                                                 rel="noreferrer noopener" target="_blank"
-                                                 class="govuk-link  govuk-link--no-visited-state">
+          <li>Virus scanning and uploading of files to your bucket via the <a
+              href="https://github.com/DEFRA/cdp-uploader"
+              rel="noreferrer noopener" target="_blank"
+              class="govuk-link  govuk-link--no-visited-state">
               cdp-uploader</a> service
           </li>
           <li>Form validation</li>
@@ -65,8 +67,8 @@
       </div>
     </div>
 
-    <div class="govuk-grid-row govuk-!-margin-bottom-4">
-      <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-three-quarters">
         <h2 class="govuk-heading-m">Multistep form with add another single file upload</h2>
         <p>
           The <a href="/plants" class="govuk-link govuk-link--no-visited-state">Plants</a> multistep form is an
@@ -75,9 +77,10 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>A multistep form flow</li>
           <li>With Redis session</li>
-          <li>Virus scanning of files via the <a href="https://github.com/DEFRA/cdp-uploader"
-                                                 rel="noreferrer noopener" target="_blank"
-                                                 class="govuk-link  govuk-link--no-visited-state">
+          <li>Virus scanning and uploading of files to your bucket via the <a
+              href="https://github.com/DEFRA/cdp-uploader"
+              rel="noreferrer noopener" target="_blank"
+              class="govuk-link  govuk-link--no-visited-state">
               cdp-uploader</a> service
           </li>
           <li>Add another functionality so you can add multiple files, one at a time</li>

--- a/src/server/plants/controllers/status-poller.js
+++ b/src/server/plants/controllers/status-poller.js
@@ -37,7 +37,7 @@ const statusPollerController = {
 
     // Mime type mismatch
     if (!hasCorrectMimeType) {
-      setError(`Files of ${acceptedMimeTypes.join(', ')} only`)
+      setError(`Files of ${acceptedMimeTypes.join(', ')}`)
 
       return h.redirect('/plants/add/upload-pictures')
     }

--- a/src/server/plants/controllers/status-poller.js
+++ b/src/server/plants/controllers/status-poller.js
@@ -1,9 +1,9 @@
 import Joi from 'joi'
 
-import { sessionNames } from '~/src/server/common/constants/session-names'
 import { saveToPlant } from '~/src/server/plants/helpers/form/save-to-plant'
 import { provideStatus } from '~/src/server/common/helpers/pre/provide-status'
 import { providePlantSession } from '~/src/server/plants/helpers/pre/provide-plant-session'
+import { populateErrorFlashMessage } from '~/src/server/common/helpers/form/populate-error-flash-message'
 
 const statusPollerController = {
   options: {
@@ -15,26 +15,43 @@ const statusPollerController = {
     }
   },
   handler: async (request, h) => {
+    const setError = populateErrorFlashMessage(request)
     const status = request.pre.status
-    const hasUploadedFile = status?.files?.length > 0
+    const fileUpload = status.files.at(0)
+    const acceptedMimeTypes = status.acceptedMimeTypes
+    const hasUploadedFile = status?.files.length > 0
+    const hasBeenVirusChecked = status?.uploadStatus === 'ready'
+    const hasPassedVirusCheck = status?.numberOfInfectedFiles === 0
+    const fileUploadSizeMb = fileUpload?.contentLength / 1024
+    const fileSizeLimitExceeded = fileUploadSizeMb > status?.maxFileSize
+    const hasCorrectMimeType = acceptedMimeTypes.includes(
+      fileUpload?.contentType
+    )
 
-    // No file uploaded - Return to upload form with error
+    // No file uploaded
     if (!hasUploadedFile) {
-      request.yar.flash(sessionNames.validationFailure, {
-        formErrors: { file: { message: 'Choose a file' } }
-      })
+      setError('Choose a file')
 
       return h.redirect('/plants/add/upload-pictures')
     }
 
-    const hasBeenVirusChecked = status?.uploadStatus === 'ready'
-    const hasPassedVirusCheck = status?.numberOfInfectedFiles === 0
+    // Mime type mismatch
+    if (!hasCorrectMimeType) {
+      setError(`Files of ${acceptedMimeTypes.join(', ')} only`)
 
-    // Virus check failed - Return to upload form with errors
+      return h.redirect('/plants/add/upload-pictures')
+    }
+
+    // Filesize limit exceeded
+    if (fileSizeLimitExceeded) {
+      setError(`Max file size of ${status?.maxFileSize}`)
+
+      return h.redirect('/plants/add/upload-pictures')
+    }
+
+    // Virus check failed
     if (hasBeenVirusChecked && !hasPassedVirusCheck) {
-      request.yar.flash(sessionNames.validationFailure, {
-        formErrors: { file: { message: 'Virus check failed' } }
-      })
+      setError('Virus check failed')
 
       return h.redirect('/plants/add/upload-pictures')
     }

--- a/src/server/plants/controllers/status-poller.js
+++ b/src/server/plants/controllers/status-poller.js
@@ -37,7 +37,11 @@ const statusPollerController = {
 
     // Mime type mismatch
     if (!hasCorrectMimeType) {
-      setError(`Files of ${acceptedMimeTypes.join(', ')}`)
+      setError(
+        `${acceptedMimeTypes
+          .map((mimeType) => '.' + mimeType.split('/')[1])
+          .join(', ')} files only`
+      )
 
       return h.redirect('/plants/add/upload-pictures')
     }

--- a/src/server/plants/controllers/upload-form.js
+++ b/src/server/plants/controllers/upload-form.js
@@ -15,7 +15,7 @@ const uploadFormController = {
     const secureUpload = await initUpload({
       successRedirect: redirectUrl,
       failureRedirect: redirectUrl,
-      acceptedMimeTypes: ['.pdf', '.csv', '.png', 'image/jpeg'],
+      acceptedMimeTypes: ['image/png', 'image/jpeg'],
       maxFileSize: 100,
       destinationBucket,
       destinationPath: '/animals',

--- a/src/server/plants/views/upload-form.njk
+++ b/src/server/plants/views/upload-form.njk
@@ -31,7 +31,7 @@
                 classes: "govuk-label--m"
               },
               hint: {
-                text: "Filetypes of .jpeg with a max size of 100kb"
+                text: "File types of .png or .jpeg with a max size of 100 MB"
               },
               errorMessage: {
                 text: formErrors.file.message


### PR DESCRIPTION
- Add `mimeType` validation
- Add `fileSize` validation

## Demo
<img width="1203" alt="Screenshot 2024-04-25 at 18 13 10" src="https://github.com/DEFRA/cdp-example-node-frontend/assets/2305016/c8a3000c-e25c-46a9-abaf-73605f705ea0">


<img width="1253" alt="Screenshot 2024-04-25 at 18 09 49" src="https://github.com/DEFRA/cdp-example-node-frontend/assets/2305016/bfd6b4c5-3fd1-40e7-bebd-a5f9d05cb26d">



## Of Note

I had a look at a custom validator using Extensions in Joi - https://joi.dev/api/?v=17.13.0#extensions 

Although its a very nice way of doing things it felt a little over engineered and more akin to validating a payload or params or query objects. 

This way its nice and simple to see whats going on and simple to add your own validation if needed. After all I feel tenants will have lots of other validation going on